### PR TITLE
ルーム作成フォームをメインページに追加

### DIFF
--- a/chatfront/src/pages/CreateRooms.js
+++ b/chatfront/src/pages/CreateRooms.js
@@ -25,7 +25,6 @@ const CreateRooms = () => {
             await axios.post('http://localhost:8000/api/rooms/', data, {
                 headers: headers
             })
-            history.push('/home')
         }
     };
     
@@ -68,9 +67,6 @@ const CreateRooms = () => {
                     </Form.Group>
                     <Button variant="primary" type="button" onClick={createRoomsBtn}>
                         ルーム作成
-                    </Button>
-                    <Button variant="primary" type="button" onClick={()=>{history.goBack()}}>
-                        ホームへ
                     </Button>
                 </Form>
             </Row>

--- a/chatfront/src/pages/Home.js
+++ b/chatfront/src/pages/Home.js
@@ -2,7 +2,7 @@ import React,{useContext} from 'react';
 import { Container } from 'react-bootstrap';
 import Profile from "../components/Profile";
 import { useHistory, Link } from "react-router-dom";
-//import CreateRooms from './CreateRooms';
+import CreateRooms from './CreateRooms';
 import RoomList from '../components/RoomList'
 import {AuthContext} from '../AuthService'
 
@@ -28,8 +28,9 @@ export default function Home() {
       <Container className="center">Welcome!!</Container>
       <Profile/>
       <button onClick={()=>{history.push('./login')}}>ログアウト</button>
-      <button onClick={() => {history.push('./createrooms')}}>ルーム作成</button>
+      {/*<button onClick={() => {history.push('./createrooms')}}>ルーム作成</button>*/}
       <RoomList/>
+      <CreateRooms />
       {/*<button><Logout /></button>*/}
     </div>
   );


### PR DESCRIPTION
配置はまだ整えられていませんが、ルーム作成機能をメインページに移動させました。
コンフリクトの関係で、まだルーム作成ボタン残っています。
<img width="773" alt="スクリーンショット 2020-10-07 19 34 23" src="https://user-images.githubusercontent.com/62993005/95320291-3d54f900-08d4-11eb-8243-eb77f70322ee.png">
